### PR TITLE
fix: extend spell check to cover .qmd files

### DIFF
--- a/opportunities.qmd
+++ b/opportunities.qmd
@@ -16,7 +16,7 @@ We welcome undergraduate students interested in gaining research experience in s
 - **Programming**: Experience with R or Python. 
 - **Coursework**: Coursework in statistics, biostatistics, and epidemiology is helpful.
 - **Biology/Public Health**: Interest in infectious diseases, immunology, or public health.
-- **Data Analysis**: Experience working with and anlyzing data. 
+- **Data Analysis**: Experience working with and analyzing data.
 - **Communication**: Strong written and verbal communication skills.
 
 ### How to Apply
@@ -63,7 +63,7 @@ We are seeking postdoctoral researchers to join our team and lead cutting-edge r
 
 ### Current Openings
 
-No current oppenings. 
+No current openings.
 
 <!-- **[Postdoctoral Research Fellow in Seroepidemiology to Advance Global Typhoid Burden Estimation and Open-Source Tool Development](opportunities/postdoc-typhoid-seroepi.qmd)** -->
 

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,4 +1,15 @@
 if (requireNamespace("spelling", quietly = TRUE)) {
   spelling::spell_check_test(vignettes = TRUE, error = FALSE,
                              skip_on_cran = TRUE)
+
+  # Also check Quarto markdown files, which spell_check_test() ignores by default
+  wordlist <- if (file.exists("inst/WORDLIST")) readLines("inst/WORDLIST") else character()
+  qmd_files <- list.files(".", pattern = "\\.qmd$", recursive = TRUE, full.names = TRUE)
+  if (length(qmd_files) > 0) {
+    results <- spelling::spell_check_files(qmd_files, ignore = wordlist, lang = "en-US")
+    if (nrow(results) > 0) {
+      print(results)
+      stop("Spelling errors found in .qmd files")
+    }
+  }
 }

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -2,11 +2,24 @@ if (requireNamespace("spelling", quietly = TRUE)) {
   spelling::spell_check_test(vignettes = TRUE, error = FALSE,
                              skip_on_cran = TRUE)
 
-  # Also check Quarto markdown files, which spell_check_test() ignores by default
-  wordlist <- if (file.exists("inst/WORDLIST")) readLines("inst/WORDLIST") else character()
-  qmd_files <- list.files(".", pattern = "\\.qmd$", recursive = TRUE, full.names = TRUE)
+  # Also check .qmd files, which spell_check_test() skips by default
+  wordlist <- if (file.exists("inst/WORDLIST")) {
+    readLines("inst/WORDLIST")
+  } else {
+    character()
+  }
+  qmd_files <- list.files(
+    ".",
+    pattern = "\\.qmd$",
+    recursive = TRUE,
+    full.names = TRUE
+  )
   if (length(qmd_files) > 0) {
-    results <- spelling::spell_check_files(qmd_files, ignore = wordlist, lang = "en-US")
+    results <- spelling::spell_check_files(
+      qmd_files,
+      ignore = wordlist,
+      lang = "en-US"
+    )
     if (nrow(results) > 0) {
       print(results)
       stop("Spelling errors found in .qmd files")

--- a/tests/spelling.R
+++ b/tests/spelling.R
@@ -1,4 +1,8 @@
 if (requireNamespace("spelling", quietly = TRUE)) {
+  # error = FALSE: the vignette/.Rmd check reports spelling problems but does
+  # not fail the test run, so pre-existing/tolerated issues there don't block
+  # CI. The .qmd check below intentionally uses a hard stop() instead: .qmd
+  # spelling is newly covered and starts clean, so any new error should fail.
   spelling::spell_check_test(vignettes = TRUE, error = FALSE,
                              skip_on_cran = TRUE)
 


### PR DESCRIPTION
Fixes #69

The `spelling` R package only checks .R, .Rmd, and man pages by default, so .qmd files were never checked. This extends `tests/spelling.R` to also run `spell_check_files()` over all .qmd files using the existing WORDLIST.

Also fixes two typos now caught by the improved check: "oppenings" → "openings" and "anlyzing" → "analyzing".

Generated with [Claude Code](https://claude.ai/code)