### PR TITLE
Restore Lab Manual link in navbar

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -17,9 +17,8 @@ website:
         text: Software
       - href: opportunities.qmd
         text: Opportunities
-      # Disabled for now - keeping content for later
-      # - href: lab-manual.qmd
-      #   text: Lab Manual
+      - href: lab-manual.qmd
+        text: Lab Manual
 
 format:
   html:


### PR DESCRIPTION
Closes #81

## Summary
- PR [#79](https://github.com/UCD-SERG/ucd-serg.github.io/pull/79) reverted the exclusion of `lab-manual.qmd` from rendering, so the page builds again, but the navbar entry in `_quarto.yml` was left commented out.
- Uncomments the `lab-manual.qmd` navbar entry so the Lab Manual page is reachable from the site menu bar (previously only reachable by direct URL, e.g. the PR preview at `/lab-manual.html`).

## Test plan
- [ ] Confirm the PR preview build shows "Lab Manual" in the navbar and the link resolves correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6SfALCWGcQKBDAQHMzcRo)_