### PR TITLE
Revert claude-review to the pull_request trigger

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,12 @@
 name: Claude Code Review
 
+# Do not switch this to `pull_request_target`.
+# Anthropic's token-exchange endpoint rejects OIDC tokens minted for that
+# event, so the job fails with "401 Unauthorized - Invalid OIDC token"
+# before Claude ever runs. See
+# https://github.com/anthropics/claude-code-action/issues/713
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
@@ -21,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
       issues: read
       id-token: write
 
@@ -30,7 +35,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Run Claude Code Review
         id: claude-review


### PR DESCRIPTION
Closes #88.

## What was broken

Every `Claude Code Review` run has failed since #83 merged, at the token-exchange step:

```
OIDC token successfully obtained
Exchanging OIDC token for app token...
App token exchange failed: 401 Unauthorized - Invalid OIDC token
```

Claude never got as far as reading a diff.
The most recent instance is
[run 30677231096](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30677231096) on #76.

## Why

#83 switched the trigger to `pull_request_target`.
Anthropic's exchange endpoint rejects OIDC tokens minted for that event.
The action's code supports it; the server side does not.
Open upstream since 2025-12-02 as
[anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713),
whose stated workaround is to use `pull_request`.

Five of five `pull_request_target` runs failed this way, and no `pull_request` run
ever has --- the two runs immediately before the switch both succeeded.
The full before/after table is in #88.

## What this changes

- Trigger back to `pull_request`, with a comment naming the upstream issue
  so the switch does not get re-applied.
- Drops `ref: ${{ github.event.pull_request.head.sha }}`.
  The action's [security doc](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md)
  warns against checking an untrusted ref into the workspace root of a job
  holding the base repository's secrets.
- Restores `pull-requests: read`.
  The action posts with its own app token, so the workflow token does not need write.

The result is byte-identical to the last version that produced successful reviews,
plus the comment.

## Fork PRs

**Corrected.** This section originally said no fork PR had ever been opened against
this repo. That is false: [#77](https://github.com/UCD-SERG/ucd-serg.github.io/pull/77)
(`imelainew/ucd-serg.github.io`) has been open since 2026-06-30. I read `main` in the
branch column as a same-repo branch without checking `head.repo.fork`.

The revert is unchanged, but the reason has to be the true one.

A fork PR gets no Claude review under **either** configuration:

- Under `pull_request`, GitHub withholds the secret and the OIDC token from a fork PR
  whatever the `permissions:` block says.
  [Run 30663424918](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30663424918)
  on #77 logs `"claude_code_oauth_token": ""` and then fails to get an OIDC token ---
  under an error message that wrongly blames a missing `id-token: write`.
- Under `pull_request_target`, the exchange 401s for every PR, forks included.
  And a working exchange would still leave the action refusing to run for a contributor
  without write access unless `allowed_non_write_users` is set, which upstream documents
  as a significant security risk.

So `pull_request_target` was not buying fork coverage at the cost of everything else.
It was reviewing nothing. This revert restores reviews for the three same-repo PRs and
leaves #77 exactly where it already was, tracked as
[#90](https://github.com/UCD-SERG/ucd-serg.github.io/issues/90).

#84 remains separate --- Copilot-authored PRs fail the same step with
`User does not have write access on this repository`, a non-collaborator triggering
actor on a same-repo branch.

## Verification

**Corrected after the first run.** This section originally said a green `claude-review`
on this PR would be the fix testing itself. That is wrong, and the reason is worth stating,
since the check does go green.

Because this PR edits the review workflow, the head version no longer matches the copy on
the default branch, so the exchange endpoint returns a workflow-validation error and the
action *skips*, exiting 0. The green check is a skip, not a review.

What the two runs do establish is where each one stopped, which is the thing in question:

| Run | Trigger | Stopped at |
| --- | --- | --- |
| [30680266785](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30680266785) | `pull_request` | workflow validation --- the OIDC token was accepted |
| [30680266779](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30680266779) | `pull_request_target` | `401 Invalid OIDC token` --- rejected outright |

Same repo, same secret, same minute, one variable. The red check is `main`'s current
workflow reviewing this PR; it cannot go green before merge and stops firing afterward.
`main` is unprotected, so nothing is blocked.

A real end-to-end review is only observable on the next PR after this one merges.


