### PR TITLE
Restore pull-requests: write for claude-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,9 +24,15 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
+    # pull-requests: write is safe here because this workflow uses the
+    # `pull_request` trigger (not `pull_request_target`): GitHub always
+    # forces a read-only GITHUB_TOKEN for PRs from forks regardless of what
+    # this block declares, so forked PRs stay read-only either way. Without
+    # write access here, same-repo PRs (the common case in this repo) never
+    # get their review posted even though the job itself succeeds.
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 


### PR DESCRIPTION
## Summary
- #89 fixed the `claude-review` job's OIDC token-exchange failure by reverting the trigger from `pull_request_target` back to `pull_request`, and in the same change narrowed `permissions.pull-requests` from `write` to `read`.
- That side effect silently breaks reviews on same-repo PRs: the job now runs to completion successfully (confirmed on [PR #87](https://github.com/UCD-SERG/ucd-serg.github.io/pull/87), run [30681158599](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30681158599/job/91318291766)) but every attempt to actually post the review is denied — the job log shows `"permission_denials_count": 8` and `No buffered inline comments` — so no review ever appears on the PR, even though the check shows green.
- Restoring `pull-requests: write` is safe: this workflow uses the `pull_request` trigger (not `pull_request_target`), and GitHub always forces a read-only `GITHUB_TOKEN` for PRs from forks regardless of what `permissions:` declares. So fork PRs stay read-only either way — this change only restores write access for same-repo PRs, which is the common case in this repo and where reviews were silently being dropped.

## Test plan
- [ ] Confirm `claude-review` posts an actual review comment on a same-repo PR (e.g. re-run against PR #87)
- [ ] Confirm a PR from a fork still only gets a read-only token (no change in behavior there)

---
_Generated by [Claude Code](https://claude.ai/code/session_012bmVHSsVxb2EZNAj719bVE)_