### PR TITLE
Allow claude-review to actually post its comment/inline review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,6 +50,13 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # The code-review plugin posts its review via `gh pr comment` (a Bash
+          # call) and the `mcp__github_inline_comment__create_inline_comment`
+          # MCP tool. Neither is allowed by default in a non-interactive run,
+          # so without this, every attempt is silently denied (see
+          # permission_denials_count in the run's result) and no review is
+          # ever posted, even though the job itself reports success.
+          claude_args: '--allowed-tools "Bash(gh pr comment *)" "mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Follow-up to #91. That PR fixed the `GITHUB_TOKEN`'s API scope (`pull-requests: write`), but tested on [PR #87](https://github.com/UCD-SERG/ucd-serg.github.io/pull/87) it turned out not to be the actual blocker — `permission_denials_count` stayed nonzero (and even grew, 8 → 17) and `claude-review` still posted zero comments on any same-repo PR.
- Root cause is a different, separate layer: Claude Code's own tool-permission gate, independent of `GITHUB_TOKEN`'s API scope. The `code-review` plugin posts its review via exactly two mechanisms (confirmed from the plugin's own command source):
  - `gh pr comment` (a `Bash` tool call), for the summary
  - `mcp__github_inline_comment__create_inline_comment` (an MCP tool), for inline comments
- Neither is in Claude Code's default allowed-tools set for a non-interactive run, so every attempt to call them was silently auto-denied (no human present to approve the permission prompt) — that's exactly what `permission_denials_count` was counting. This matches the workflow file's own half-written hint that was sitting there as a dead comment: `# claude_args: '--allowed-tools Bash(gh pr *)'`.
- Fix: set `claude_args: '--allowed-tools "Bash(gh pr comment *)" "mcp__github_inline_comment__create_inline_comment"'` so both mechanisms the plugin actually needs are explicitly allowed.

## Test plan
- [ ] Confirm a `claude` review comment (summary or inline) actually appears on a same-repo PR after this merges — would be the first genuine one ever recorded in this repo (see the historical review-comment audit in [PR #91's discussion](https://github.com/UCD-SERG/ucd-serg.github.io/pull/91))
- [ ] Confirm `permission_denials_count` drops to 0 (or near 0) in the run's result log

---
_Generated by [Claude Code](https://claude.ai/code/session_012bmVHSsVxb2EZNAj719bVE)_