### PR TITLE
Temporarily enable show_full_output on claude-review (diagnostic)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -57,6 +57,10 @@ jobs:
           # permission_denials_count in the run's result) and no review is
           # ever posted, even though the job itself reports success.
           claude_args: '--allowed-tools "Bash(gh pr comment *)" "mcp__github_inline_comment__create_inline_comment"'
+          # TEMPORARY: reveals which specific tool call is still being denied
+          # (permission_denials_count was 1 on the last run, down from 17,
+          # but still zero reviews posted). Remove once diagnosed.
+          show_full_output: true
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Follow-up to #92. That fix dropped `permission_denials_count` from 17 → 1 (confirmed on [PR #87](https://github.com/UCD-SERG/ucd-serg.github.io/pull/87), run [30684616369](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30684616369/job/91327903272)), but the review still isn't posted — still `No buffered inline comments` and zero `claude` comments/reviews on the PR.
- `claude-code-action` hides Claude's detailed tool-call stream by default ("full output hidden for security"), so there's no way to see which specific call the remaining single denial corresponds to from the log alone — only the count.
- This PR temporarily sets `show_full_output: true` so the next run's log reveals the exact blocked tool call, so the actual fix (extending `--allowed-tools` correctly) can be targeted instead of guessed.

**This is a diagnostic-only change** — intent is to revert `show_full_output` once the cause is identified.

## Test plan
- [ ] After merge, trigger `claude-review` on a same-repo PR and inspect the verbose log for the specific denied tool call
- [ ] Follow up with a fix PR for that specific call, and revert `show_full_output` back to unset/false

---
_Generated by [Claude Code](https://claude.ai/code/session_012bmVHSsVxb2EZNAj719bVE)_