### PR TITLE
Match claude-review's allowed-tools to the plugin's own frontmatter

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -50,17 +50,14 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # The code-review plugin posts its review via `gh pr comment` (a Bash
-          # call) and the `mcp__github_inline_comment__create_inline_comment`
-          # MCP tool. Neither is allowed by default in a non-interactive run,
-          # so without this, every attempt is silently denied (see
-          # permission_denials_count in the run's result) and no review is
-          # ever posted, even though the job itself reports success.
-          claude_args: '--allowed-tools "Bash(gh pr comment *)" "mcp__github_inline_comment__create_inline_comment"'
-          # TEMPORARY: reveals which specific tool call is still being denied
-          # (permission_denials_count was 1 on the last run, down from 17,
-          # but still zero reviews posted). Remove once diagnosed.
-          show_full_output: true
+          # This must match the code-review plugin's own `allowed-tools`
+          # frontmatter (plugins/code-review/commands/code-review.md in
+          # anthropics/claude-code) exactly. claude_args replaces the
+          # effective allowlist rather than adding to it, so a narrower list
+          # here (as a previous version of this file had) denies the
+          # plugin's own steps - e.g. `gh pr diff`/`gh pr view` calls it
+          # makes to gather context - not just the final posting step.
+          claude_args: '--allowed-tools "Bash(gh issue view:*)" "Bash(gh search:*)" "Bash(gh issue list:*)" "Bash(gh pr comment:*)" "Bash(gh pr diff:*)" "Bash(gh pr view:*)" "Bash(gh pr list:*)" "mcp__github_inline_comment__create_inline_comment"'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## Summary
- Follow-up to #92/#93. #93's diagnostic `show_full_output: true` revealed why the review still wasn't posting despite `permission_denials_count` dropping to ~1: `claude_args`'s `--allowed-tools` **replaces** the effective tool allowlist rather than adding to it.
- #92's narrower list (`Bash(gh pr comment *)` + the inline-comment tool) denied the plugin's own read-side steps too — the verbose log from run [30685553432](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30685553432/job/91330470808) (PR #87, commit `644d3f4`) shows denied calls to `gh pr diff`, `gh pr view` (via manual `gh api` workarounds), `git diff`, `cat`, `grep`, `python3`, and a recursive `Skill` call — and **zero** attempts at `gh pr comment` or the inline-comment tool at all. The agent never got far enough to post.
- Fetched the plugin's actual source directly (`plugins/code-review/commands/code-review.md` in `anthropics/claude-code`) rather than relying on an AI-summarized fetch (which is what led to the incomplete list in #92). Its frontmatter declares the full tool set it needs:
  ```yaml
  allowed-tools: Bash(gh issue view:*), Bash(gh search:*), Bash(gh issue list:*), Bash(gh pr comment:*), Bash(gh pr diff:*), Bash(gh pr view:*), Bash(gh pr list:*), mcp__github_inline_comment__create_inline_comment
  ```
- This PR sets `claude_args` to match that list exactly, and removes #93's temporary `show_full_output: true` now that it's served its purpose.

## Test plan
- [ ] Confirm a `claude` review comment (summary and/or inline) actually appears on a same-repo PR after this merges — this repo's first genuine one, per the historical audit in #91's discussion
- [ ] Confirm `permission_denials_count` is 0 (or only reflects genuinely out-of-scope calls) in the run's result

---
_Generated by [Claude Code](https://claude.ai/code/session_012bmVHSsVxb2EZNAj719bVE)_