### PR TITLE
Add comment-triggered code review for PRs from forks

### DIFF
--- a/.github/workflows/claude-review-comment.yml
+++ b/.github/workflows/claude-review-comment.yml
@@ -1,0 +1,49 @@
+name: Claude Code Review (fork PRs)
+
+# claude-code-review.yml can't review PRs from forks: `pull_request` events
+# from forks never receive an OIDC token at all (GitHub doesn't set
+# ACTIONS_ID_TOKEN_REQUEST_URL for them, regardless of `id-token: write`),
+# and switching that workflow to `pull_request_target` doesn't help either -
+# Anthropic's token-exchange endpoint rejects OIDC tokens minted under
+# pull_request_target (see anthropics/claude-code-action#713). `issue_comment`
+# is subject to neither restriction, so a trusted maintainer can request a
+# review this way for any PR, fork or not.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  claude-review:
+    if: |
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '@claude review') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          # refs/pull/<n>/head exists in this repo for every PR, including
+          # from forks, so this checks out the actual PR contents without
+          # needing any credentials on the fork.
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.issue.number }}'
+          # Keep in sync with claude-code-review.yml - see that file for why
+          # this must match the code-review plugin's own allowed-tools
+          # frontmatter exactly.
+          claude_args: '--allowed-tools "Bash(gh issue view:*)" "Bash(gh search:*)" "Bash(gh issue list:*)" "Bash(gh pr comment:*)" "Bash(gh pr diff:*)" "Bash(gh pr view:*)" "Bash(gh pr list:*)" "mcp__github_inline_comment__create_inline_comment"'


### PR DESCRIPTION
## Summary
- `claude-code-review.yml` (fixed for same-repo PRs across #89/#91/#92/#93/#94) structurally cannot review PRs from forks, no matter how it's configured:
  - Its `pull_request` trigger never receives an OIDC token for fork PRs at all — GitHub doesn't set `ACTIONS_ID_TOKEN_REQUEST_URL` for those runs regardless of `id-token: write`. Confirmed on [PR #77](https://github.com/UCD-SERG/ucd-serg.github.io/pull/77), run [30686460528/job/91333167166](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30686460528/job/91333167166):
    ```
    Failed to get OIDC token: ... Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
    Attempt 1/2/3 failed: Could not fetch an OIDC token.
    ```
  - Switching to `pull_request_target` (which *does* get OIDC tokens for forks) doesn't help either — that's exactly what #89 moved *away* from, because Anthropic's token-exchange endpoint rejects OIDC tokens minted under that event ([anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713)).
  - So there's no trigger-event combination that makes the automatic workflow work for forks.
- Fix: a new workflow, `claude-review-comment.yml`, triggered by `issue_comment` instead. That event isn't subject to either restriction (not `pull_request` from a fork, not `pull_request_target`), so it works for any PR, fork or not.
  - Gated with `github.event.comment.author_association` to `OWNER`/`MEMBER`/`COLLABORATOR` — comment-triggered workflows aren't covered by the "require approval for first-time contributors" setting that gates fork `pull_request` runs, so this keeps it to trusted maintainers rather than any commenter.
  - Checks out `refs/pull/<n>/head`, which GitHub mirrors into the base repo for every PR (including forks) — no fork credentials needed.
  - Runs the same `code-review` plugin with the same `claude_args` allowlist as `claude-code-review.yml`, so the review itself behaves identically.
- Usage: a maintainer comments `@claude review` on the PR (e.g. #77).

## Test plan
- [ ] Comment `@claude review` on a fork PR (e.g. #77) and confirm a real review comment appears
- [ ] Confirm a comment from a non-collaborator does *not* trigger the workflow

---
_Generated by [Claude Code](https://claude.ai/code/session_012bmVHSsVxb2EZNAj719bVE)_