### PR TITLE
Pass --comment so claude-review actually posts its review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,7 +49,12 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          # `--comment` is load-bearing, not decoration. The code-review
+          # plugin's step 7 reads: "If `--comment` argument was NOT provided,
+          # stop here. Do not post any GitHub comments." Without it the review
+          # runs, finds whatever it finds, prints to the job log, and posts
+          # nothing - with a green check. See issue #96.
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # This must match the code-review plugin's own `allowed-tools`
           # frontmatter (plugins/code-review/commands/code-review.md in
           # anthropics/claude-code) exactly. claude_args replaces the


### PR DESCRIPTION
Closes #96.

## The actual cause

The `code-review` plugin gates **all** posting on a `--comment` argument. From its own command definition, [`plugins/code-review/commands/code-review.md`](https://github.com/anthropics/claude-code/blob/main/plugins/code-review/commands/code-review.md) step 7:

> If `--comment` argument was NOT provided, stop here. **Do not post any GitHub comments.**

Our prompt has never passed it. So every review this repo has ever run has behaved exactly as designed: review the PR, print the findings to the job log, post nothing, exit 0.

`claude` has zero review comments across #78, #79, #80, #86, #87, #92, #93, and #94.

## This was not a permissions problem

[#91](https://github.com/UCD-SERG/ucd-serg.github.io/pull/91) (`pull-requests: write`) and [#92](https://github.com/UCD-SERG/ucd-serg.github.io/pull/92)/[#94](https://github.com/UCD-SERG/ucd-serg.github.io/pull/94) (allowlist) were all treating a symptom. I own a share of that: #89's permission change rested on an untested premise, and the two rounds of allowlist work that followed inherited the framing.

The reasoning error is worth naming, because the evidence was sitting in plain text the whole time. Reviews on `Morrison-Lab/ai-config` say it verbatim in their own output:

> No `--comment` flag was passed in the arguments, so per the review process I'll output findings here rather than posting to GitHub.

I read that sentence twice tonight while working other PRs and did not connect it to this symptom.

## Why ai-config looks like it works

It consumes `d-morrison/gha`'s reusable review workflow, which has its own step that reads the last assistant message out of the execution output and posts it with `gh issue comment`. Its review comments are authored by **`github-actions[bot]`**, not `claude` --- that authorship is the tell.

This repo calls `anthropics/claude-code-action` directly, so nothing wraps the output and the plugin's own posting path is the only one available. That path is gated on `--comment`.

## Verification, and its limit

The YAML parses and the prompt string ends with `--comment`, confirmed by loading the file rather than eyeballing it.

Beyond that, **this PR cannot test itself**: it edits `claude-code-review.yml`, so its own run skips at workflow validation and exits 0 without reviewing anything. That is the same structural limit #89 and #91 hit.

The real test is the first push to an open PR after this merges --- #76, #86, or #77. A `claude`-authored comment there would be this repository's first.

## Still open, deliberately not bundled

`permission_denials_count` is 4, down from 8 ([run 30686664862](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/30686664862)). Those four are unexplained and did not stop the review completing, so they are a separate question --- most likely the plugin's subagent launches, since its steps 1 through 5 each launch agents and `Task` is not in the allowlist. Tracked in #96's closing section; worth a `show_full_output` run once posting works, rather than changing two things at once.
