### PR TITLE
Migrate claude.yml (@claude agent) to Morrison-Lab/gha's claude.yml@v2

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,12 +17,30 @@
 # does not run the action's built-in branch-setup / git-push / response-comment
 # machinery -- gha's own post-steps do that instead -- and it ships a default
 # `claude-args` that REPLACES the effective tool allowlist rather than adding
-# to it. Net effect: Bash is narrowed to an enumerated list, and `git push`
-# (every variant), `gh pr create`, and the write forms of `gh api` are denied
-# outright, with pushing owned by gha's post-steps. `quarto render` is on the
-# allowlist; `quarto preview`, `quarto check`, and `Rscript -e` forms outside
-# the six listed are not. Override with the `claude-args` input if a run turns
-# out to need something the default list omits.
+# to it.
+#
+# Net effect: Bash is narrowed to an enumerated list. `git push` is denied in
+# every listed variant, with pushing owned by gha's post-steps. `quarto render`
+# is allowed; `quarto preview`, `quarto check`, and `Rscript -e` forms outside
+# the six listed are not. `gh pr create` is OMITTED from the allowlist rather
+# than denied -- unavailable either way, but the distinction matters under the
+# override note below, since an override loses denials and not omissions.
+#
+# Be precise about `gh api`: what is denied is the three prefix patterns
+# `gh api -X`, `gh api --method`, and `gh api graphql`, against an allow of
+# `gh api:*`. That is narrower than "write forms are denied". `gh api --help`
+# states the method "is `GET` normally and `POST` if any parameters were
+# added", so a `-f`/`-F`/`--input` call is a POST that no deny pattern
+# matches, and the patterns are prefix matches, so a reordered
+# `gh api -H ... -X POST <url>` is not matched either. With a write-scoped
+# GITHUB_TOKEN the residual surface is real; upstream calls the trusted-author
+# gate its primary containment, which is why the caller-side gate below
+# matters. Filed upstream as Morrison-Lab/gha#616.
+#
+# Overriding `claude-args` REPLACES both halves, so a caller that sets it to
+# add one tool silently drops all thirteen deny patterns above. If an override
+# is ever needed, copy upstream's `--disallowedTools` string verbatim and
+# extend only the allow list.
 name: Claude Code
 
 on:
@@ -36,8 +54,10 @@ on:
     # anyone is assigned to an already-open issue whose body or title mentions
     # @claude, and that run now holds `contents: write` rather than `read`.
     # Retained for parity rather than dropped, since narrowing the trigger set
-    # is a behaviour change this migration did not set out to make. Note gha
-    # pairs `assigned` with its `eager-pr` input, which is not set here.
+    # is a behaviour change this migration did not set out to make. The input
+    # that governs assignment as a trigger in its own right is
+    # `dispatch-on-assignee`, left at its '[]' default -- see the note beside
+    # it below for why setting it would need a matching caller-side clause.
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
@@ -90,12 +110,18 @@ jobs:
       # #83, #87, #89, #91, #92, #93, #94, #95 and #97 all touched
       # .github/workflows/.
       #
-      # Two consequences, now live rather than hypothetical. Cost: unlike
-      # GITHUB_TOKEN, a PAT push DOES trigger other push-based workflows, so
-      # Claude's pushes now fire this repo's push/pull_request workflows.
-      # Benefit: for the same reason a Claude push fires `synchronize`, which
-      # a GITHUB_TOKEN push does not -- so Claude's commits get an automatic
-      # review even without the dispatch path.
+      # One consequence, and it is the same mechanism read two ways. A
+      # GITHUB_TOKEN push creates no workflow runs at all; a PAT push does.
+      # gha pushes only to a claude/... branch or a PR head, never to `main`,
+      # so NOTHING here fires via `push` -- publish.yml, check-spelling.yaml
+      # and lint-project.yaml all filter their push trigger to main.
+      #
+      # What changes is `pull_request`: a Claude push now produces a
+      # `synchronize` event, so preview.yml, check-spelling.yaml,
+      # lint-project.yaml and claude-code-review.yml each gain a run. That is
+      # the cost (four extra runs per Claude push) and the benefit (Claude's
+      # commits get an automatic review even without the dispatch path) at
+      # once -- not two separate effects.
       WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       # SUBMODULES_TOKEN is deliberately omitted: this repo has no submodules.
     with:
@@ -113,27 +139,51 @@ jobs:
       # files contain an R chunk, and _quarto.yml declares only `format: html`,
       # so no render path needs R.
       #
-      # The cost of enabling it is not merely setup time. gha's setup-r path
-      # runs setup-r-dependencies including `local::.`, i.e. it installs this
-      # repo as an R package on every run. Nothing on main exercises that
+      # The cost of enabling it is setup time on every run: gha's setup-r path
+      # runs setup-r-dependencies including `local::.`, installing this repo
+      # as an R package, and nothing on main exercises that today
       # (lint-project.yaml installs only lintr; check-spelling.yaml runs in a
-      # rocker container), and DESCRIPTION sets `LazyData: true` with no data/
-      # directory, a known source of R CMD INSTALL complaints. A failure there
-      # happens BEFORE Claude runs, so it would kill every @claude invocation.
+      # rocker container).
       #
-      # Flip to true if R work becomes routine here, after verifying the
-      # `local::.` install actually succeeds.
+      # What this GIVES UP is worth naming: five of the six `Rscript -e`
+      # grants in gha's default tool allowlist are dead without R, so Claude
+      # can edit R here but cannot lint, document, or test what it edits. An
+      # R fix would land unverified, with lint-project.yaml as the first thing
+      # to catch a mistake. That is the trade being made, and it is the reason
+      # to revisit this if R work becomes routine.
+      #
+      # Note `setup-r: false` also skips pandoc, which gha gates on the same
+      # input. No impact here: `quarto render` uses Quarto's bundled pandoc,
+      # and the one pandoc shell-out in R/create_pub_listing.R is unreachable
+      # without R anyway.
       setup-r: false
       # Upstream defaults this repo is accepting deliberately, named rather
       # than inherited silently -- each changes behaviour relative to the
       # hand-rolled workflow:
       #   use-ai-config: true         installs the Morrison-Lab/ai-config plugin
-      #   report-cost: true           posts a dollar-cost comment to the thread
+      #   report-cost: true           appends the run's dollar cost to whichever
+      #                               comment gha already posts back to the
+      #                               thread; only posts a comment of its own on
+      #                               the commit-and-dispatch path
       #   mark-ready-for-review: true takes Claude's draft PRs out of draft
       #   reviewer: 'd-morrison'      re-requested as reviewer on every Claude
       #                               push to a PR. New behaviour here; set to
       #                               '' to suppress it.
+      #   review-workflow-file:       'claude-code-review.yml' -- the file the
+      #                               `actions: write` grant above dispatches,
+      #                               and the reason this PR depends on #110
       #   eager-pr: false             no draft PR opened up front
-      #   dispatch-on-assignee: '[]'  assignment alone does not trigger a run
+      #   dispatch-on-assignee: '[]'  assignment alone does not trigger a run.
+      #                               Setting it here alone does NOT enable it:
+      #                               the caller `if:` above has no assignment
+      #                               clause, so the reusable workflow would
+      #                               never be invoked and the input would do
+      #                               nothing. Both halves are required.
+      #   trusted-bot-logins: '[]'    same both-halves rule -- admitting an App
+      #                               bot needs the login in this input AND an
+      #                               OR'd login check in the caller `if:`.
+      #                               While both stay '[]', the caller gate
+      #                               above and gha's own trusted-author gate
+      #                               agree; they diverge as soon as either is set.
       #   link-skills: false          not applicable; this repo has no top-level
       #                               skills/ (its one skill is .claude/skills/)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -71,18 +71,31 @@ jobs:
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}   # unset here; empty when using OAuth
-      # Not set in this repo. Without it the integrated GITHUB_TOKEN cannot
-      # push changes under .github/workflows/ (GitHub rejects them without the
-      # `workflows` scope); the run reports the rejection and posts Claude's
-      # commits as a git format-patch so they survive. Worth adding, since
-      # much of this repo's recent @claude work has been workflow edits.
+      # LIVE as of 2026-08-24 16:35Z: a WORKFLOW_TOKEN secret exists at the
+      # UCD-SERG org level with visibility "all repositories", so this
+      # forwarding is active rather than aspirational. Confirmed reachable
+      # from this repo, and separately verified to authenticate as a user PAT
+      # that can push a commit touching .github/workflows/ -- i.e. it does
+      # carry the `workflows` scope.
       #
-      # Two consequences to weigh first. Cost: unlike GITHUB_TOKEN, a PAT push
-      # DOES trigger other push-based workflows, so adding it would fire
-      # publish.yml and check-spelling.yaml on Claude's pushes. Benefit: for
-      # the same reason it also makes a Claude push fire `synchronize`, which
-      # a GITHUB_TOKEN push does not -- so it would give Claude's commits an
-      # automatic review even without the dispatch path.
+      # Forwarding it explicitly is load-bearing, not decorative. A reusable
+      # workflow only ever sees the secrets its caller passes, so an org
+      # secret this block omitted would be invisible to gha's workflow no
+      # matter how broad its visibility.
+      #
+      # Without it the integrated GITHUB_TOKEN cannot push changes under
+      # .github/workflows/ (GitHub rejects them without the `workflows`
+      # scope); gha reports the rejection and posts Claude's commits as a
+      # git format-patch so they survive. That matters here specifically:
+      # #83, #87, #89, #91, #92, #93, #94, #95 and #97 all touched
+      # .github/workflows/.
+      #
+      # Two consequences, now live rather than hypothetical. Cost: unlike
+      # GITHUB_TOKEN, a PAT push DOES trigger other push-based workflows, so
+      # Claude's pushes now fire this repo's push/pull_request workflows.
+      # Benefit: for the same reason a Claude push fires `synchronize`, which
+      # a GITHUB_TOKEN push does not -- so Claude's commits get an automatic
+      # review even without the dispatch path.
       WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
       # SUBMODULES_TOKEN is deliberately omitted: this repo has no submodules.
     with:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,14 @@
+# Caller stub for Morrison-Lab/gha's reusable claude.yml (agent mode).
+#
+# Replaces this repo's hand-rolled workflow, which called
+# anthropics/claude-code-action directly. See #100, and #99 for the two gaps
+# this closes (read-only `pull-requests` permission, and no author check on
+# who may trigger an @claude run).
+#
+# Secrets are passed explicitly rather than with `secrets: inherit`: GitHub
+# only inherits secrets into a reusable workflow owned by the same org/user,
+# and this is a UCD-SERG repo calling a Morrison-Lab workflow, so `inherit`
+# would hand it an empty token.
 name: Claude Code
 
 on:
@@ -12,39 +23,40 @@ on:
 
 jobs:
   claude:
+    # Cheap caller-side gate: only invoke the reusable workflow when an
+    # @claude mention is present AND the author is trusted
+    # (OWNER/MEMBER/COLLABORATOR). This mirrors the reusable workflow's own
+    # trusted-author gate as defense-in-depth: without it the run is still
+    # skipped downstream, but only after invoking a workflow that was granted
+    # elevated permissions and passed secrets. The hand-rolled workflow this
+    # replaces had no author check at all -- the second half of #99.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write        # push branches
+      pull-requests: write   # open/update PRs -- was `read`, the first half of #99
+      issues: write          # comment back on the thread
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # This is an optional setting that allows Claude to read CI results on PRs
-          additional_permissions: |
-            actions: read
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
-
+      actions: write         # dispatch claude-code-review.yml on Claude's commits
+    uses: Morrison-Lab/gha/.github/workflows/claude.yml@v2
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}   # unset here; empty when using OAuth
+      # Not set in this repo. Without it the integrated GITHUB_TOKEN cannot
+      # push changes under .github/workflows/ (GitHub rejects them without the
+      # `workflows` scope); the run reports the rejection and posts Claude's
+      # commits as a git format-patch so they survive. Worth adding, since
+      # much of this repo's recent @claude work has been workflow edits.
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+    with:
+      # This is a Quarto site, so give Claude the toolchain to render and
+      # check its own .qmd edits. The hand-rolled workflow installed neither
+      # Quarto nor R.
+      install-quarto: true
+      # The repo carries an R package skeleton (DESCRIPTION, R/, tests/), so
+      # install its R dependencies. This is gha's default; stated explicitly
+      # because it materially changes job setup time.
+      setup-r: true

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -5,10 +5,24 @@
 # this closes (read-only `pull-requests` permission, and no author check on
 # who may trigger an @claude run).
 #
-# Secrets are passed explicitly rather than with `secrets: inherit`: GitHub
-# only inherits secrets into a reusable workflow owned by the same org/user,
-# and this is a UCD-SERG repo calling a Morrison-Lab workflow, so `inherit`
-# would hand it an empty token.
+# Secrets are passed explicitly rather than with `secrets: inherit`. GitHub
+# documents `inherit` as available to a caller in the same organization or
+# enterprise as the reusable workflow; this is a UCD-SERG repo calling a
+# Morrison-Lab one, so relying on it would mean relying on those two orgs
+# sharing an enterprise. Passing explicitly removes the question.
+#
+# BEHAVIOURAL CHANGE worth knowing before reading further: the reusable
+# workflow sets a `prompt:`, which puts claude-code-action in AGENT mode
+# rather than the TAG mode this repo's hand-rolled workflow used. Agent mode
+# does not run the action's built-in branch-setup / git-push / response-comment
+# machinery -- gha's own post-steps do that instead -- and it ships a default
+# `claude-args` that REPLACES the effective tool allowlist rather than adding
+# to it. Net effect: Bash is narrowed to an enumerated list, and `git push`
+# (every variant), `gh pr create`, and the write forms of `gh api` are denied
+# outright, with pushing owned by gha's post-steps. `quarto render` is on the
+# allowlist; `quarto preview`, `quarto check`, and `Rscript -e` forms outside
+# the six listed are not. Override with the `claude-args` input if a run turns
+# out to need something the default list omits.
 name: Claude Code
 
 on:
@@ -17,6 +31,13 @@ on:
   pull_request_review_comment:
     types: [created]
   issues:
+    # Unchanged from the hand-rolled workflow, so this is not a new trigger.
+    # Its cost did change: `assigned` re-fires a full agent run whenever
+    # anyone is assigned to an already-open issue whose body or title mentions
+    # @claude, and that run now holds `contents: write` rather than `read`.
+    # Retained for parity rather than dropped, since narrowing the trigger set
+    # is a behaviour change this migration did not set out to make. Note gha
+    # pairs `assigned` with its `eager-pr` input, which is not set here.
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
@@ -40,7 +61,12 @@ jobs:
       pull-requests: write   # open/update PRs -- was `read`, the first half of #99
       issues: write          # comment back on the thread
       id-token: write
-      actions: write         # dispatch claude-code-review.yml on Claude's commits
+      # Needed for the review dispatch below. That dispatch only resolves once
+      # #110 puts a `workflow_dispatch` trigger on claude-code-review.yml --
+      # until then `gh workflow run` cannot resolve the target and gha's
+      # dispatch step falls through to a `::warning::`. See the ordering note
+      # in this PR's description; merge #110 first.
+      actions: write
     uses: Morrison-Lab/gha/.github/workflows/claude.yml@v2
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -50,13 +76,51 @@ jobs:
       # `workflows` scope); the run reports the rejection and posts Claude's
       # commits as a git format-patch so they survive. Worth adding, since
       # much of this repo's recent @claude work has been workflow edits.
+      #
+      # Two consequences to weigh first. Cost: unlike GITHUB_TOKEN, a PAT push
+      # DOES trigger other push-based workflows, so adding it would fire
+      # publish.yml and check-spelling.yaml on Claude's pushes. Benefit: for
+      # the same reason it also makes a Claude push fire `synchronize`, which
+      # a GITHUB_TOKEN push does not -- so it would give Claude's commits an
+      # automatic review even without the dispatch path.
       WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+      # SUBMODULES_TOKEN is deliberately omitted: this repo has no submodules.
     with:
       # This is a Quarto site, so give Claude the toolchain to render and
       # check its own .qmd edits. The hand-rolled workflow installed neither
-      # Quarto nor R.
+      # Quarto nor R. Note gha's input installs TinyTeX unconditionally with
+      # no way to opt out, which this html-only site does not need -- the
+      # existing publish.yml and preview.yml already pay that cost too.
       install-quarto: true
-      # The repo carries an R package skeleton (DESCRIPTION, R/, tests/), so
-      # install its R dependencies. This is gha's default; stated explicitly
-      # because it materially changes job setup time.
-      setup-r: true
+      # Deliberately FALSE, against gha's default of true.
+      #
+      # This repo's own copilot-setup-steps.yml reached the same conclusion
+      # and recorded it: "R and renv setup steps are disabled for now as we
+      # don't have any R code to run yet." Confirmed still true --- zero .qmd
+      # files contain an R chunk, and _quarto.yml declares only `format: html`,
+      # so no render path needs R.
+      #
+      # The cost of enabling it is not merely setup time. gha's setup-r path
+      # runs setup-r-dependencies including `local::.`, i.e. it installs this
+      # repo as an R package on every run. Nothing on main exercises that
+      # (lint-project.yaml installs only lintr; check-spelling.yaml runs in a
+      # rocker container), and DESCRIPTION sets `LazyData: true` with no data/
+      # directory, a known source of R CMD INSTALL complaints. A failure there
+      # happens BEFORE Claude runs, so it would kill every @claude invocation.
+      #
+      # Flip to true if R work becomes routine here, after verifying the
+      # `local::.` install actually succeeds.
+      setup-r: false
+      # Upstream defaults this repo is accepting deliberately, named rather
+      # than inherited silently -- each changes behaviour relative to the
+      # hand-rolled workflow:
+      #   use-ai-config: true         installs the Morrison-Lab/ai-config plugin
+      #   report-cost: true           posts a dollar-cost comment to the thread
+      #   mark-ready-for-review: true takes Claude's draft PRs out of draft
+      #   reviewer: 'd-morrison'      re-requested as reviewer on every Claude
+      #                               push to a PR. New behaviour here; set to
+      #                               '' to suppress it.
+      #   eager-pr: false             no draft PR opened up front
+      #   dispatch-on-assignee: '[]'  assignment alone does not trigger a run
+      #   link-skills: false          not applicable; this repo has no top-level
+      #                               skills/ (its one skill is .claude/skills/)


### PR DESCRIPTION
> [!IMPORTANT]
> Merge #110 first. gha's reusable `claude.yml` dispatches the review workflow
> via `workflow_dispatch`, and this repo's current bespoke
> `claude-code-review.yml` has no `workflow_dispatch` trigger, so that dispatch
> would fail until #110 lands. The two PRs touch disjoint files, so there is no
> merge conflict --- only an ordering constraint.

Closes #100

Replaces the hand-rolled `.github/workflows/claude.yml`, which called `anthropics/claude-code-action@v1` directly, with a caller stub for `Morrison-Lab/gha`'s reusable `claude.yml@v2`.

## This closes #99, which is the point

#99 tracks two gaps in the bespoke workflow. Both are closed here, and both are closed by adopting gha's baseline rather than by patching:

| #99 gap | Before | After |
| --- | --- | --- |
| `pull-requests: read` | Claude could not open or update a PR | `pull-requests: write` |
| No author check on `@claude` triggers | any commenter could start a run | `OWNER`/`MEMBER`/`COLLABORATOR` gate on all four event types |

The author gate is defense-in-depth rather than the only check: the reusable workflow has its own trusted-author gate, but without the caller-side one the run is only skipped *after* invoking a workflow that was already granted elevated permissions and passed secrets.

## What is preserved

- **All four trigger events**, unchanged: `issue_comment`, `pull_request_review_comment`, `issues [opened, assigned]`, `pull_request_review [submitted]`.
- **`additional_permissions: actions: read`**, so Claude can still read CI results on PRs. The reusable workflow sets this internally; I checked rather than assuming:
  ```yaml
  additional_permissions: |
    actions: read
  ```
- **`CLAUDE_CODE_OAUTH_TOKEN`** as the auth mechanism.

## What changes

- **Permissions widen** to gha's documented set for this workflow: `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: write`. The last is new and is what lets Claude dispatch a review of its own commits --- which is the coupling with #110.
- **Quarto is installed** (`install-quarto: true`). The hand-rolled workflow installed neither Quarto nor R, so Claude could edit `.qmd` files without being able to render them or check its own work. Note gha's input installs TinyTeX unconditionally with no opt-out; this site is html-only, though `publish.yml` and `preview.yml` already pay that same cost today.
- **R is NOT installed** (`setup-r: false`), deliberately against gha's default of `true`. See below.
- **Mode switch: tag mode to agent mode.** The reusable workflow sets a `prompt:`, which puts `claude-code-action` in agent mode. Agent mode skips the action's built-in branch-setup / git-push / response-comment machinery (gha's post-steps do that instead) and ships a default `claude-args` that **replaces** the effective tool allowlist rather than extending it. Net effect: Bash is narrowed to an enumerated list, `git push` is denied in every listed variant, and `gh pr create` is omitted from the allowlist. This is the largest behavioural change in the diff and is documented in the file. Note the `gh api` denials are narrower than they look --- see the round-2 self-review below and Morrison-Lab/gha#616.
- **Secrets are passed explicitly** rather than via `secrets: inherit`: GitHub only inherits secrets into a reusable workflow owned by the same org/user, and this is a UCD-SERG repo calling a Morrison-Lab workflow, so `inherit` would supply an empty token.

## `WORKFLOW_TOKEN` is forwarded, and the secret is now live

**Corrected since this PR was opened.** When first written, this repo had exactly one Actions secret and the `WORKFLOW_TOKEN` forwarding was aspirational --- the workflow comment said "Not set in this repo". That is no longer true. A `WORKFLOW_TOKEN` secret was added at the **UCD-SERG org level on 2026-08-24 at 16:35:37Z**, visibility "all repositories", and it is reachable here:

```
$ gh api repos/UCD-SERG/ucd-serg.github.io/actions/organization-secrets --jq '.secrets[].name'
OPENROUTER_API_KEY
WORKFLOW_TOKEN
```

It authenticates as a user PAT and can push a commit touching `.github/workflows/`, so it genuinely carries the `workflows` scope. The comment in the workflow has been corrected to match. Worth flagging as a category: that was a state claim that expired between measurement and merge, not a mistake in reasoning.

**Forwarding it explicitly is load-bearing, not decorative.** A reusable workflow only ever sees the secrets its caller passes, so an org-level secret this `secrets:` block omitted would be invisible to gha's workflow no matter how broad its visibility. That is exactly the defect filed today against two sibling repos --- UCD-SERG/serocalculator#663 and UCD-SERG/serodynamics#297, both gha callers that fail to forward it. This PR avoids that class.

Why it matters here specifically: `.github/workflows/` is what `@claude` has mostly been asked to edit in this repo (#83, #87, #89, #91, #92, #93, #94, #95, #97). Without the token those pushes are rejected, and gha falls back to posting the commits as a `git format-patch`.

Two consequences, now live rather than hypothetical:

- **Cost.** Unlike `GITHUB_TOKEN`, a PAT push *does* trigger other push-based workflows, so Claude's pushes now set off this repo's `push` / `pull_request` workflows.
- **Benefit.** For the same reason a Claude push fires `synchronize`, which a `GITHUB_TOKEN` push does not --- so Claude's commits get an automatic review even without the dispatch path.

`SUBMODULES_TOKEN` is deliberately not forwarded: this repo has no submodules. `ANTHROPIC_API_KEY` is forwarded but unset; auth is via `CLAUDE_CODE_OAUTH_TOKEN`.

## Why `setup-r: false`, against gha's default

This is the one place the migration deviates from gha's defaults, and the evidence is the repo's own:

- **This repo already decided this.** `.github/workflows/copilot-setup-steps.yml` line 12: *"R and renv setup steps are disabled for now as we don't have any R code to run yet."* Its `setup-r` block is commented out for the same reason.
- **Still true.** `grep -rn '```{r' --include='*.qmd' .` returns **0** files, and `_quarto.yml` declares only `format: html`. No render path needs R.
- **The cost is setup time on every run.** gha's `setup-r` path runs `setup-r-dependencies` including `local::.`, i.e. it installs this repo as an R package on every invocation, and nothing on `main` exercises that today (`lint-project.yaml` installs only `lintr`; `check-spelling.yaml` runs in a `rocker/tidyverse` container).

> **Corrected.** An earlier revision of this body claimed `LazyData: true` with no `data/` directory is "a known source of `R CMD INSTALL` complaints" that "would kill every `@claude` invocation". Round 2 of the self-review measured it: `R CMD INSTALL` completes with no warning and no error, and `R CMD build` silently drops the field. That was an invented failure mode supporting a decision already made, and it is the finding from this PR I'd most want on the record. The decision stands on the rest of the rationale above, all of which was independently verified.

- **What it gives up, stated plainly.** Five of the six `Rscript -e` grants in gha's default allowlist are dead without R, so Claude can edit R here but cannot lint, document, or test what it edits. An R fix would land unverified, with `lint-project.yaml` as the first thing to catch a mistake. That is the trade, and the reason to revisit if R work becomes routine.

An earlier revision of this PR set `setup-r: true` on the reasoning that the repo "carries an R package skeleton". That reasoning did not engage with `copilot-setup-steps.yml`, which had already reached the opposite conclusion on the same repo. Flip it back if R work becomes routine here, after verifying the `local::.` install actually succeeds.

## Inherited defaults, named rather than left silent

Each of these changes behaviour relative to the hand-rolled workflow, and each is enumerated in a comment in the file rather than set (so the `with:` block carries only deviations):

| Input | Default | Effect |
| --- | --- | --- |
| `use-ai-config` | `true` | installs the `Morrison-Lab/ai-config` plugin |
| `report-cost` | `true` | posts a dollar-cost comment to the thread |
| `mark-ready-for-review` | `true` | takes Claude's draft PRs out of draft |
| `reviewer` | `'d-morrison'` | **re-requested as reviewer on every Claude push to a PR** |
| `eager-pr` | `false` | no draft PR opened up front |
| `dispatch-on-assignee` | `'[]'` | assignment alone does not trigger a run |
| `link-skills` | `false` | not applicable; no top-level `skills/` here |

The `reviewer` one is worth a second look before merge --- it is new behaviour and it is not obvious from the stub. Set it to `''` to suppress.

`SUBMODULES_TOKEN` is deliberately not passed: this repo has no submodules.

## Not changed

The `on:` block is byte-identical to the hand-rolled workflow's, including `issues: [opened, assigned]`. Its *cost* did change --- `assigned` re-fires a full agent run whenever anyone is assigned to an already-open issue mentioning `@claude`, and that run now holds `contents: write` rather than `read` --- so it is documented in the file rather than silently retained. Narrowing the trigger set is a behaviour change this migration did not set out to make.

## Validation

`actionlint` and `yamllint` clean on the new file, and it is ASCII-only.

## Review status: blocked on an external verdict, not ready

`check-pr-fully-clean.py` exits 1 here with "No automated review comments or reviews found". That is accurate.

The cause is #105: this repo's hand-rolled `claude-review` executes and posts nothing. A clean reproduction landed on **this PR** --- run [32751977837](https://github.com/UCD-SERG/ucd-serg.github.io/actions/runs/32751977837), `is_error: false`, `num_turns: 4`, `total_cost_usd: 0.0520`, `permission_denials_count: 1`, green check, no comment --- written up on #105. This PR touches no workflow file, so the self-modification guard that explains #110's missing review does not apply here. The two PRs went unreviewed for different reasons, and only #110's resolves on merge.

Per `self-review-fallback`, the fallback is an adversarial self-review (posted separately on this PR), with a cross-vendor reviewer requested in parallel. A human approval is required to merge regardless: the `main` ruleset requires 1 approving review, `require_last_push_approval`, and thread resolution.

The standing rule authorizing this migration is Morrison-Lab/ai-config#2127, merged 2026-08-24 at 16:42Z.
